### PR TITLE
IRIS 27650 ng select search trim update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## Since 3.2.0, notable changes are on [Releases Page](https://github.com/ng-select/ng-select/releases)
+### [3.2.1](https://github.com/natlex/ng-select/compare/v8.0.4...v3.2.1) (2022-09-25)
 
 ### [3.1.1](https://github.com/ng-select/ng-select/compare/v3.1.0...v3.1.1) (2019-10-19)
 

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -124,7 +124,7 @@
 
         <div class="ng-option" [class.ng-option-marked]="!itemsList.markedItem" (mouseover)="itemsList.unmarkItem()" role="option" (click)="selectTag()" *ngIf="showAddTag">
             <ng-template #defaultTagTemplate>
-                <span><span class="ng-tag-label">{{addTagText}}</span>"{{searchTerm}}"</span>
+                <span><span class="ng-tag-label">{{addTagText}}</span>"{{searchTerm.trim()}}"</span>
             </ng-template>
 
             <ng-template

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -569,6 +569,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 
     selectTag() {
         let tag;
+        this.searchTerm = this.searchTerm.trim();
         if (isFunction(this.addTag)) {
             tag = (<AddTagFn>this.addTag)(this.searchTerm);
         } else {
@@ -637,7 +638,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             return;
         }
 
-        this.searchTerm = term;
+        this.searchTerm = term.trim();
         if (this._isTypeahead && (this._validTerm || this.minTermLength === 0)) {
             this.typeahead.next(term);
         }

--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlex/ng-select",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Angular ng-select - All in One UI Select, Multiselect and Autocomplete",
   "author": "@natlex/ng-select",
   "license": "MIT",


### PR DESCRIPTION
1. No spaces in search query anymore. It will be purified to be able to find term ignoring spaces.
2. Add new option also ignores spaces