### PR TITLE
fix: IRIS-27650 ng-select search with spaces fix

### DIFF
--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -124,7 +124,7 @@
 
         <div class="ng-option" [class.ng-option-marked]="!itemsList.markedItem" (mouseover)="itemsList.unmarkItem()" role="option" (click)="selectTag()" *ngIf="showAddTag">
             <ng-template #defaultTagTemplate>
-                <span><span class="ng-tag-label">{{addTagText}}</span>"{{searchTerm.trim()}}"</span>
+                <span><span class="ng-tag-label">{{addTagText}}</span>"{{searchTerm}}"</span>
             </ng-template>
 
             <ng-template

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -124,7 +124,7 @@
 
         <div class="ng-option" [class.ng-option-marked]="!itemsList.markedItem" (mouseover)="itemsList.unmarkItem()" role="option" (click)="selectTag()" *ngIf="showAddTag">
             <ng-template #defaultTagTemplate>
-                <span><span class="ng-tag-label">{{addTagText}}</span>"{{searchTerm}}"</span>
+                <span><span class="ng-tag-label">{{addTagText}}</span>"{{searchTerm.trim()}}"</span>
             </ng-template>
 
             <ng-template

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -569,6 +569,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 
     selectTag() {
         let tag;
+        this.searchTerm = this.searchTerm.trim();
         if (isFunction(this.addTag)) {
             tag = (<AddTagFn>this.addTag)(this.searchTerm);
         } else {
@@ -637,7 +638,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             return;
         }
 
-        this.searchTerm = term;
+        this.searchTerm = term.trim();
         if (this._isTypeahead && (this._validTerm || this.minTermLength === 0)) {
             this.typeahead.next(term);
         }


### PR DESCRIPTION
1. No spaces in search query anymore. It will be purified to be able to find term ignoring spaces.
2. Add new option also ignores spaces